### PR TITLE
Reject sending same transaction twice

### DIFF
--- a/x/bridge/keeper/transaction.go
+++ b/x/bridge/keeper/transaction.go
@@ -66,6 +66,11 @@ func (k Keeper) SubmitTx(ctx sdk.Context, transaction *types.Transaction, submit
 		txSubmissions.TxHash = k.TxHash(transaction).String()
 	}
 
+	_, ok := k.GetTransaction(ctx, types.TransactionId(transaction))
+	if ok {
+		return errorsmod.Wrap(types.ErrTranscationAlreadyProcessed, "transaction already exists")
+	}
+
 	// If tx has been submitted before with the same address new submission is rejected
 	if isSubmitter(txSubmissions.Submitters, submitter) {
 		return errorsmod.Wrap(types.ErrTranscationAlreadySubmitted,

--- a/x/bridge/keeper/transaction.go
+++ b/x/bridge/keeper/transaction.go
@@ -68,7 +68,7 @@ func (k Keeper) SubmitTx(ctx sdk.Context, transaction *types.Transaction, submit
 
 	_, ok := k.GetTransaction(ctx, types.TransactionId(transaction))
 	if ok {
-		return errorsmod.Wrap(types.ErrTranscationAlreadyProcessed, "transaction already exists")
+		return nil
 	}
 
 	// If tx has been submitted before with the same address new submission is rejected

--- a/x/bridge/types/errors.go
+++ b/x/bridge/types/errors.go
@@ -32,4 +32,5 @@ var (
 	ErrReferralIdMustBePositive     = errorsmod.Register(ModuleName, 1121, "referral id must be positive")
 	ErrTokenIdMustBePositive        = errorsmod.Register(ModuleName, 1122, "token id must be positive")
 	ErrInvalidDataType              = errorsmod.Register(ModuleName, 1123, "invalid data type")
+	ErrTranscationAlreadyProcessed  = errorsmod.Register(ModuleName, 1124, "transaction already processed")
 )


### PR DESCRIPTION
This minor fix allows us to use a centralized signature service if we need it 